### PR TITLE
Add module assignment feature to Person

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,6 +18,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_INVALID_MODULE_CODE = "The module code provided is invalid";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
+import seedu.address.model.Model;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.person.Person;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.module.Module;
+import seedu.address.model.person.module.ModuleRegistry;
+
+public class AddModuleCommand extends Command {
+
+    public static final String COMMAND_WORD = "module";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds or replaces a module to "
+            + "the person identified by the index "
+            + "number used in the last person listing.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_MODULE + "[MODULE CODE]\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_MODULE + "CS2040S";
+
+    public static final String MESSAGE_ARGUMENTS = "Index: %1$d, Module: %2$s";
+
+    private final Index targetIndex;
+    private final String moduleCode;
+
+    public AddModuleCommand(Index index, String remark) {
+        requireAllNonNull(index, remark);
+
+        this.targetIndex = index;
+        this.moduleCode = remark;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToAddModule = lastShownList.get(targetIndex.getZeroBased());
+
+        Module module = ModuleRegistry.getModuleByCode(this.moduleCode);
+        if (module == null) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MODULE_CODE);
+        }
+        personToAddModule.setModule(module);
+
+        throw new CommandException(String.format(MESSAGE_ARGUMENTS, this.targetIndex.getOneBased(), this.moduleCode));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof AddModuleCommand m)) {
+            return false;
+        }
+
+        return targetIndex.equals(m.targetIndex) && moduleCode.equals(m.moduleCode);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
@@ -1,21 +1,28 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 
 import java.util.List;
-import seedu.address.model.Model;
+
 import seedu.address.commons.core.index.Index;
-import seedu.address.model.person.Person;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.module.Module;
 import seedu.address.model.person.module.ModuleRegistry;
 
+/**
+ * Adds or replaces a module for a person identified by their index in the last displayed person list.
+ */
 public class AddModuleCommand extends Command {
 
     public static final String COMMAND_WORD = "module";
 
+    /**
+     * Usage message for the {@code AddModuleCommand}, detailing command syntax and an example.
+     */
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds or replaces a module to "
             + "the person identified by the index "
             + "number used in the last person listing.\n"
@@ -29,32 +36,55 @@ public class AddModuleCommand extends Command {
     private final Index targetIndex;
     private final String moduleCode;
 
-    public AddModuleCommand(Index index, String remark) {
-        requireAllNonNull(index, remark);
+    /**
+     * Constructs an {@code AddModuleCommand} with the given person index and module code.
+     *
+     * @param index The index of the person in the displayed list.
+     * @param moduleCode The module code to assign to the person.
+     */
+    public AddModuleCommand(Index index, String moduleCode) {
+        requireAllNonNull(index, moduleCode);
 
         this.targetIndex = index;
-        this.moduleCode = remark;
+        this.moduleCode = moduleCode;
     }
 
+    /**
+     * Executes the command to assign a module to the specified person.
+     *
+     * @param model The model containing the list of persons.
+     * @return A {@code CommandResult} indicating the outcome of the execution.
+     * @throws CommandException If the index is invalid or the module code is not recognized.
+     */
     @Override
     public CommandResult execute(Model model) throws CommandException {
         List<Person> lastShownList = model.getFilteredPersonList();
 
+        // Check if the target index is within the list bounds
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         Person personToAddModule = lastShownList.get(targetIndex.getZeroBased());
 
+        // Retrieve the module from the registry
         Module module = ModuleRegistry.getModuleByCode(this.moduleCode);
         if (module == null) {
             throw new CommandException(Messages.MESSAGE_INVALID_MODULE_CODE);
         }
+
+        // Assign the module to the person
         personToAddModule.setModule(module);
 
         throw new CommandException(String.format(MESSAGE_ARGUMENTS, this.targetIndex.getOneBased(), this.moduleCode));
     }
 
+    /**
+     * Checks if this {@code AddModuleCommand} is equal to another object.
+     *
+     * @param other The other object to compare with.
+     * @return {@code true} if both objects are equivalent, {@code false} otherwise.
+     */
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/seedu/address/logic/parser/AddModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddModuleCommandParser.java
@@ -6,23 +6,42 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.commands.AddModuleCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 
+/**
+ * Parses input arguments and creates a new {@code AddModuleCommand} object.
+ */
 public class AddModuleCommandParser implements Parser<AddModuleCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code AddModuleCommand}
+     * and returns an {@code AddModuleCommand} object for execution.
+     *
+     * @param args User input arguments as a String.
+     * @return A new instance of {@code AddModuleCommand} with the parsed values.
+     * @throws ParseException If the input does not conform to the expected format.
+     */
     public AddModuleCommand parse(String args) throws ParseException {
         requireNonNull(args);
+
+        // Tokenizes the input arguments based on the module prefix.
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MODULE);
 
         Index index;
         try {
+            // Parses the index from the command's preamble (e.g., "1" in "module 1 m/CS1010").
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddModuleCommand.MESSAGE_USAGE), ive);
+            // Throws a ParseException if the index is invalid.
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddModuleCommand.MESSAGE_USAGE), ive);
         }
 
+        // Extracts the module code from the parsed arguments, defaulting to an empty string if absent.
         String moduleCode = argMultimap.getValue(PREFIX_MODULE).orElse("");
 
+        // Returns the parsed command object with the extracted index and module code.
         return new AddModuleCommand(index, moduleCode);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddModuleCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.commands.AddModuleCommand;
+
+public class AddModuleCommandParser implements Parser<AddModuleCommand> {
+    public AddModuleCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MODULE);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddModuleCommand.MESSAGE_USAGE), ive);
+        }
+
+        String moduleCode = argMultimap.getValue(PREFIX_MODULE).orElse("");
+
+        return new AddModuleCommand(index, moduleCode);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.AddModuleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case AddModuleCommand.COMMAND_WORD:
+            return new AddModuleCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddModuleCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -17,7 +18,6 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.AddModuleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-
+    public static final Prefix PREFIX_MODULE = new Prefix("m/");
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -8,8 +8,8 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.tag.Tag;
 import seedu.address.model.person.module.Module;
+import seedu.address.model.tag.Tag;
 
 /**
  * Represents a Person in the address book.

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.person.module.Module;
 
 /**
  * Represents a Person in the address book.
@@ -24,6 +25,7 @@ public class Person {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private Module module;
 
     /**
      * Every field must be present and not null.
@@ -54,11 +56,22 @@ public class Person {
     }
 
     /**
+     * To be used later.
+     */
+    public Module getModule() {
+        return this.module;
+    }
+
+    /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    public void setModule(Module module) {
+        this.module = module;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/module/Module.java
+++ b/src/main/java/seedu/address/model/person/module/Module.java
@@ -1,22 +1,48 @@
 package seedu.address.model.person.module;
 
+/**
+ * Represents a Module that stores the module code and name.
+ * This class is immutable.
+ */
 public class Module {
-    private final String moduleCode;
-    private final String moduleName;
+    private final String moduleCode; // Unique identifier for the module (e.g., "CS1010")
+    private final String moduleName; // Full name of the module (e.g., "Programming Methodology")
 
+    /**
+     * Constructs a Module with the specified module code and name.
+     *
+     * @param moduleCode The unique code of the module.
+     * @param moduleName The name of the module.
+     */
     public Module(String moduleCode, String moduleName) {
         this.moduleCode = moduleCode;
         this.moduleName = moduleName;
     }
 
+    /**
+     * Returns the module code.
+     *
+     * @return The module code as a String.
+     */
     public String getModuleCode() {
         return this.moduleCode;
     }
 
+    /**
+     * Returns the module name.
+     *
+     * @return The module name as a String.
+     */
     public String getModuleName() {
         return this.moduleName;
     }
 
+    /**
+     * Returns a string representation of the module in the format:
+     * "moduleCode moduleName".
+     *
+     * @return A formatted string representation of the module.
+     */
     @Override
     public String toString() {
         return this.moduleCode + " " + this.moduleName;

--- a/src/main/java/seedu/address/model/person/module/Module.java
+++ b/src/main/java/seedu/address/model/person/module/Module.java
@@ -1,0 +1,24 @@
+package seedu.address.model.person.module;
+
+public class Module {
+    private final String moduleCode;
+    private final String moduleName;
+
+    public Module(String moduleCode, String moduleName) {
+        this.moduleCode = moduleCode;
+        this.moduleName = moduleName;
+    }
+
+    public String getModuleCode() {
+        return this.moduleCode;
+    }
+
+    public String getModuleName() {
+        return this.moduleName;
+    }
+
+    @Override
+    public String toString() {
+        return this.moduleCode + " " + this.moduleName;
+    }
+}

--- a/src/main/java/seedu/address/model/person/module/ModuleRegistry.java
+++ b/src/main/java/seedu/address/model/person/module/ModuleRegistry.java
@@ -1,9 +1,13 @@
 package seedu.address.model.person.module;
 
-import java.util.List;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
+/**
+ * Module Registry enum
+ * Stores all preset modules
+ */
 public enum ModuleRegistry {
     CS1231S(new Module("CS1231S", "Discrete Structures")),
     CS2030S(new Module("CS2030S", "Programming Methodology II")),

--- a/src/main/java/seedu/address/model/person/module/ModuleRegistry.java
+++ b/src/main/java/seedu/address/model/person/module/ModuleRegistry.java
@@ -1,0 +1,44 @@
+package seedu.address.model.person.module;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public enum ModuleRegistry {
+    CS1231S(new Module("CS1231S", "Discrete Structures")),
+    CS2030S(new Module("CS2030S", "Programming Methodology II")),
+    CS2040S(new Module("CS2040S", "Data Structures and Algorithms")),
+    CS2100(new Module("CS2100", "Computer Organisation")),
+    CS2103T(new Module("CS2103T", "Software Engineering")),
+    CS2106(new Module("CS2106", "Introduction to Operating Systems")),
+    CS2109S(new Module("CS2109S", "Introduction to AI and Machine Learning")),
+    CS3230(new Module("CS3230", "Design and Analysis of Algorithms")),
+    CS2101(new Module("CS2101", "Effective Communication for Computing Professionals"));
+
+    private final Module module;
+
+    ModuleRegistry(Module module) {
+        this.module = module;
+    }
+
+    public Module getModule() {
+        return module;
+    }
+
+    public static Module getModuleByCode(String code) {
+        for (ModuleRegistry entry : ModuleRegistry.values()) {
+            if (entry.module.getModuleCode().equalsIgnoreCase(code)) {
+                return entry.module;
+            }
+        }
+        return null;
+    }
+
+    public static List<Module> getAllModules() {
+        List<Module> modules = new ArrayList<>();
+        for (ModuleRegistry entry : ModuleRegistry.values()) {
+            modules.add(entry.module);
+        }
+        return Collections.unmodifiableList(modules);
+    }
+}


### PR DESCRIPTION
Introduced the ability to assign a single module to a Person using the new `AddModuleCommand`. The command follows the syntax: `module <index of person> m/<module code>`.

Key changes:
- Added `Module` class to represent individual modules.
- Created `ModuleRegistry` enum to store predefined modules.
- Implemented `AddModuleCommand` to handle module assignment.
- Developed `AddModuleCommandParser` to parse user input.
- Updated `Person` class to include a `Module` field.

This implementation ensures that each Person can only have **one** module at a time. Future updates may extend support for multiple modules if needed.