### PR TITLE
Cmd nav

### DIFF
--- a/src/main/java/seedu/address/logic/HistoryNavigator.java
+++ b/src/main/java/seedu/address/logic/HistoryNavigator.java
@@ -1,0 +1,21 @@
+package seedu.address.logic;
+
+/**
+ * Represents a function that navigates a history based on input
+ */
+public interface HistoryNavigator {
+    /**
+     * Returns the current entry in the history
+     */
+    String current();
+
+    /**
+     * Navigates the history in the backward direction and returns the result.
+     */
+    String backward();
+
+    /**
+     * Navigates the history in the forward direction and returns the result.
+     */
+    String forward();
+}

--- a/src/main/java/seedu/address/logic/InputHistory.java
+++ b/src/main/java/seedu/address/logic/InputHistory.java
@@ -8,11 +8,13 @@ import java.util.Stack;
  * Manages input history of the command line
  */
 public class InputHistory {
+    public static final int MAX_SIZE = 16;
     private final Deque<String> back;
     private final Stack<String> front;
 
-    public static final int MAX_SIZE = 16;
-
+    /**
+     * Creates a {@code InputHistory} with blank history
+     */
     public InputHistory() {
         this.back = new LinkedList<>();
         this.front = new Stack<>();
@@ -64,6 +66,11 @@ public class InputHistory {
         }
     }
 
+    /**
+     * Returns a proxy class for easy navigation of the history
+     *
+     * @return The proxy
+     */
     public HistoryNavigator getNavigator() {
         return new HistoryNavigator() {
             @Override

--- a/src/main/java/seedu/address/logic/InputHistory.java
+++ b/src/main/java/seedu/address/logic/InputHistory.java
@@ -1,0 +1,96 @@
+package seedu.address.logic;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Stack;
+
+/**
+ * Manages input history of the command line
+ */
+public class InputHistory {
+    private final Deque<String> back;
+    private final Stack<String> front;
+
+    public static final int MAX_SIZE = 16;
+
+    public InputHistory() {
+        this.back = new LinkedList<>();
+        this.front = new Stack<>();
+    }
+
+    /**
+     * Shifts the history one command back if there are commands behind and returns the newly pointed command,
+     * else returns the currently pointed command.
+     *
+     * @return The pointed command (May be null)
+     */
+    public String navigateBackward() {
+        if (back.isEmpty()) {
+            return null;
+        } else {
+            return front.push(back.removeFirst());
+        }
+    }
+
+    /**
+     * Shifts the history one command forward if there are commands in front and returns the newly pointed command,
+     * else returns the currently pointed command.
+     *
+     * @return The pointed command (May be null)
+     */
+    public String navigateForward() {
+        if (front.size() < 2) {
+            return null;
+        } else {
+            back.push(front.pop());
+            return front.peek();
+        }
+    }
+
+    /**
+     * Shifts the history to the command before {@code commandText} was entered, then adds {@code commandText}
+     * to history. If the history is over {@link InputHistory.MAX_SIZE}, older entries are deleted until history
+     * is {@link InputHistory.MAX_SIZE} again.
+     *
+     * @param commandText The new command to add to history
+     */
+    public void enterCommand(String commandText) {
+        while (!front.isEmpty()) {
+            back.push(front.pop());
+        }
+        front.push(commandText);
+
+        if (back.size() > MAX_SIZE - 1) {
+            back.removeLast();
+        }
+    }
+
+    public HistoryNavigator getNavigator() {
+        return new HistoryNavigator() {
+            @Override
+            public String backward() {
+                return InputHistory.this.navigateBackward();
+            }
+
+            @Override
+            public String forward() {
+                return InputHistory.this.navigateForward();
+            }
+        };
+    }
+
+    /**
+     * Represents a function that navigates the command history based on input
+     */
+    public interface HistoryNavigator {
+        /**
+         * Navigates the command history in the backward direction and returns the result.
+         */
+        String backward();
+
+        /**
+         * Navigates the command history in the forward direction and returns the result.
+         */
+        String forward();
+    }
+}

--- a/src/main/java/seedu/address/logic/InputHistory.java
+++ b/src/main/java/seedu/address/logic/InputHistory.java
@@ -28,7 +28,11 @@ public class InputHistory {
      */
     public String navigateBackward() {
         if (back.isEmpty()) {
-            return null;
+            if (front.isEmpty()) {
+                return null;
+            } else {
+                return front.peek();
+            }
         } else {
             return front.push(back.removeFirst());
         }
@@ -42,7 +46,11 @@ public class InputHistory {
      */
     public String navigateForward() {
         if (front.size() < 2) {
-            return null;
+            if (front.isEmpty()) {
+                return null;
+            } else {
+                return front.peek();
+            }
         } else {
             back.push(front.pop());
             return front.peek();

--- a/src/main/java/seedu/address/logic/InputHistory.java
+++ b/src/main/java/seedu/address/logic/InputHistory.java
@@ -21,6 +21,19 @@ public class InputHistory {
     }
 
     /**
+     * Returns the currently pointed command.
+     *
+     * @return The pointed command (May be null)
+     */
+    public String navigateCurrent() {
+        if (front.isEmpty()) {
+            return null;
+        } else {
+            return front.peek();
+        }
+    }
+
+    /**
      * Shifts the history one command back if there are commands behind and returns the newly pointed command,
      * else returns the currently pointed command.
      *
@@ -28,11 +41,7 @@ public class InputHistory {
      */
     public String navigateBackward() {
         if (back.isEmpty()) {
-            if (front.isEmpty()) {
-                return null;
-            } else {
-                return front.peek();
-            }
+            return this.navigateCurrent();
         } else {
             return front.push(back.removeFirst());
         }
@@ -46,11 +55,7 @@ public class InputHistory {
      */
     public String navigateForward() {
         if (front.size() < 2) {
-            if (front.isEmpty()) {
-                return null;
-            } else {
-                return front.peek();
-            }
+            return this.navigateCurrent();
         } else {
             back.push(front.pop());
             return front.peek();
@@ -82,6 +87,11 @@ public class InputHistory {
     public HistoryNavigator getNavigator() {
         return new HistoryNavigator() {
             @Override
+            public String current() {
+                return InputHistory.this.navigateCurrent();
+            }
+
+            @Override
             public String backward() {
                 return InputHistory.this.navigateBackward();
             }
@@ -91,20 +101,5 @@ public class InputHistory {
                 return InputHistory.this.navigateForward();
             }
         };
-    }
-
-    /**
-     * Represents a function that navigates the command history based on input
-     */
-    public interface HistoryNavigator {
-        /**
-         * Navigates the command history in the backward direction and returns the result.
-         */
-        String backward();
-
-        /**
-         * Navigates the command history in the forward direction and returns the result.
-         */
-        String forward();
     }
 }

--- a/src/main/java/seedu/address/logic/InputHistory.java
+++ b/src/main/java/seedu/address/logic/InputHistory.java
@@ -49,8 +49,7 @@ public class InputHistory {
 
     /**
      * Shifts the history to the command before {@code commandText} was entered, then adds {@code commandText}
-     * to history. If the history is over {@link InputHistory.MAX_SIZE}, older entries are deleted until history
-     * is {@link InputHistory.MAX_SIZE} again.
+     * to history. If the history is over {@link InputHistory.MAX_SIZE}, the oldest entry is deleted.
      *
      * @param commandText The new command to add to history
      */

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,14 +1,10 @@
 package seedu.address.ui;
 
-import java.util.function.Function;
-
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
-import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
-import seedu.address.logic.InputHistory;
 import seedu.address.logic.InputHistory.HistoryNavigator;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -37,7 +33,6 @@ public class CommandBox extends UiPart<Region> {
         this.historyNavigator = historyNavigator;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
-//        commandTextField.setOnKeyPressed(event -> handleKeyPress(event));
         commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, this::handleKeyPress);
     }
 
@@ -69,15 +64,15 @@ public class CommandBox extends UiPart<Region> {
         }
 
         String history = switch (keyEvent.getCode()) {
-            case UP -> {
-                keyEvent.consume();
-                yield historyNavigator.backward();
-            }
-            case DOWN -> {
-                keyEvent.consume();
-                yield historyNavigator.forward();
-            }
-            default -> null;
+        case UP -> {
+            keyEvent.consume();
+            yield historyNavigator.backward();
+        }
+        case DOWN -> {
+            keyEvent.consume();
+            yield historyNavigator.forward();
+        }
+        default -> null;
         };
         if (history != null) {
             commandTextField.setText(history);

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -5,7 +5,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
-import seedu.address.logic.InputHistory.HistoryNavigator;
+import seedu.address.logic.HistoryNavigator;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,9 +1,15 @@
 package seedu.address.ui;
 
+import java.util.function.Function;
+
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import seedu.address.logic.InputHistory;
+import seedu.address.logic.InputHistory.HistoryNavigator;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,6 +23,7 @@ public class CommandBox extends UiPart<Region> {
     private static final String FXML = "CommandBox.fxml";
 
     private final CommandExecutor commandExecutor;
+    private final HistoryNavigator historyNavigator;
 
     @FXML
     private TextField commandTextField;
@@ -24,11 +31,14 @@ public class CommandBox extends UiPart<Region> {
     /**
      * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
      */
-    public CommandBox(CommandExecutor commandExecutor) {
+    public CommandBox(CommandExecutor commandExecutor, HistoryNavigator historyNavigator) {
         super(FXML);
         this.commandExecutor = commandExecutor;
+        this.historyNavigator = historyNavigator;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+//        commandTextField.setOnKeyPressed(event -> handleKeyPress(event));
+        commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, this::handleKeyPress);
     }
 
     /**
@@ -46,6 +56,31 @@ public class CommandBox extends UiPart<Region> {
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+        }
+    }
+
+    /**
+     * Handles any key pressed event.
+     */
+    @FXML
+    private void handleKeyPress(KeyEvent keyEvent) {
+        if (!keyEvent.getCode().isArrowKey()) {
+            return;
+        }
+
+        String history = switch (keyEvent.getCode()) {
+            case UP -> {
+                keyEvent.consume();
+                yield historyNavigator.backward();
+            }
+            case DOWN -> {
+                keyEvent.consume();
+                yield historyNavigator.forward();
+            }
+            default -> null;
+        };
+        if (history != null) {
+            commandTextField.setText(history);
         }
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -12,6 +12,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.InputHistory;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -29,6 +30,7 @@ public class MainWindow extends UiPart<Stage> {
 
     private Stage primaryStage;
     private Logic logic;
+    private InputHistory history;
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
@@ -59,6 +61,7 @@ public class MainWindow extends UiPart<Stage> {
         // Set dependencies
         this.primaryStage = primaryStage;
         this.logic = logic;
+        this.history = new InputHistory();
 
         // Configure the UI
         setWindowDefaultSize(logic.getGuiSettings());
@@ -119,7 +122,7 @@ public class MainWindow extends UiPart<Stage> {
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand);
+        CommandBox commandBox = new CommandBox(this::executeCommand, this.history.getNavigator());
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 
@@ -174,6 +177,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
+            history.enterCommand(commandText);
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());

--- a/src/test/java/seedu/address/logic/InputHistoryTest.java
+++ b/src/test/java/seedu/address/logic/InputHistoryTest.java
@@ -13,6 +13,7 @@ public class InputHistoryTest {
     public void navigate_emptyHistory_returnsNull() {
         InputHistory history = new InputHistory();
         assertNull(history.navigateBackward());
+        assertNull(history.navigateForward());
     }
 
     @Test
@@ -47,5 +48,18 @@ public class InputHistoryTest {
         InputHistory.HistoryNavigator navigator = history.getNavigator();
         assertEquals(TEST_COMMAND, navigator.backward());
         assertEquals(TEST_COMMAND_2, navigator.forward());
+    }
+
+    @Test
+    public void enterCommand_overSize_dropsLast() {
+        InputHistory history = new InputHistory();
+        for (int i = 0; i < InputHistory.MAX_SIZE + 1; i++) {
+            history.enterCommand(String.format("%d", i));
+        }
+        String result = "";
+        for (int i = 0; i < InputHistory.MAX_SIZE + 1; i++) {
+            result = history.navigateBackward();
+        }
+        assertEquals("1", result);
     }
 }

--- a/src/test/java/seedu/address/logic/InputHistoryTest.java
+++ b/src/test/java/seedu/address/logic/InputHistoryTest.java
@@ -12,6 +12,7 @@ public class InputHistoryTest {
     @Test
     public void navigate_emptyHistory_returnsNull() {
         InputHistory history = new InputHistory();
+        assertNull(history.navigateCurrent());
         assertNull(history.navigateBackward());
         assertNull(history.navigateForward());
     }
@@ -21,7 +22,7 @@ public class InputHistoryTest {
         InputHistory history = new InputHistory();
 
         history.enterCommand(TEST_COMMAND);
-        assertEquals(TEST_COMMAND, history.navigateBackward());
+        assertEquals(TEST_COMMAND, history.navigateCurrent());
     }
 
     @Test
@@ -40,12 +41,13 @@ public class InputHistoryTest {
     }
 
     @Test
-    public void navigator_equivalentToSelf() {
+    public void navigate_navigator_equivalentToSelf() {
         InputHistory history = new InputHistory();
         history.enterCommand(TEST_COMMAND);
         history.enterCommand(TEST_COMMAND_2);
 
-        InputHistory.HistoryNavigator navigator = history.getNavigator();
+        HistoryNavigator navigator = history.getNavigator();
+        assertEquals(TEST_COMMAND_2, navigator.current());
         assertEquals(TEST_COMMAND, navigator.backward());
         assertEquals(TEST_COMMAND_2, navigator.forward());
     }

--- a/src/test/java/seedu/address/logic/InputHistoryTest.java
+++ b/src/test/java/seedu/address/logic/InputHistoryTest.java
@@ -1,0 +1,51 @@
+package seedu.address.logic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+public class InputHistoryTest {
+    public static final String TEST_COMMAND = "abc";
+    public static final String TEST_COMMAND_2 = "def";
+
+    @Test
+    public void navigate_emptyHistory_returnsNull() {
+        InputHistory history = new InputHistory();
+        assertNull(history.navigateBackward());
+    }
+
+    @Test
+    public void navigate_history_returnsValue() {
+        InputHistory history = new InputHistory();
+
+        history.enterCommand(TEST_COMMAND);
+        assertEquals(TEST_COMMAND, history.navigateBackward());
+    }
+
+    @Test
+    public void navigateBackward_backwardEnd_returnsValue() {
+        InputHistory history = new InputHistory();
+        history.enterCommand(TEST_COMMAND);
+        history.navigateBackward();
+        assertEquals(TEST_COMMAND, history.navigateBackward());
+    }
+
+    @Test
+    public void navigateForward_forwardEnd_returnsValue() {
+        InputHistory history = new InputHistory();
+        history.enterCommand(TEST_COMMAND);
+        assertEquals(TEST_COMMAND, history.navigateForward());
+    }
+
+    @Test
+    public void navigator_equivalentToSelf() {
+        InputHistory history = new InputHistory();
+        history.enterCommand(TEST_COMMAND);
+        history.enterCommand(TEST_COMMAND_2);
+
+        InputHistory.HistoryNavigator navigator = history.getNavigator();
+        assertEquals(TEST_COMMAND, navigator.backward());
+        assertEquals(TEST_COMMAND_2, navigator.forward());
+    }
+}


### PR DESCRIPTION
Add a plaintext command history that saves up to 16 past command texts,
the history is navigated via the UP and DOWN arrow keys.
Resolves #61 

**Known Issues**
- There seems to have been a feature in JavaFX whereby the UP and DOWN arrow keys puts the cursor at the front/end of the text in the textfield, respectively. This behaviour was overridden.
- ~~No tests on the history managing class~~