### PR TITLE
Phone Input Validation

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -30,6 +30,8 @@ import seedu.address.model.person.Telegram;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_FIND_INVALID_PHONE = "Phone keywords should only contain digits, "
+            + "may optionally start with a '+', and must be between 1 and 17 digits long.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -198,8 +200,7 @@ public class ParserUtil {
     public static void validatePhoneKeywords(List<String> keywords) throws ParseException {
         for (String keyword : keywords) {
             if (!keyword.matches("\\+?\\d{1,17}")) {
-                throw new ParseException("Phone keywords should only contain digits, may optionally start with a '+', "
-                        + "and must be between 1 and 17 digits long.");
+                throw new ParseException(MESSAGE_FIND_INVALID_PHONE);
             }
         }
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -197,8 +197,9 @@ public class ParserUtil {
      */
     public static void validatePhoneKeywords(List<String> keywords) throws ParseException {
         for (String keyword : keywords) {
-            if (!keyword.matches("\\d+")) {
-                throw new ParseException("Phone number must only contain digits.");
+            if (!keyword.matches("\\+?\\d{1,17}")) {
+                throw new ParseException("Phone keywords should only contain digits, may optionally start with a '+', "
+                        + "and must be between 1 and 17 digits long.");
             }
         }
     }

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,9 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should contain only digits, optionally start with a ‘+’, "
+                    + "and be between 3 and 17 digits long.";
+    public static final String VALIDATION_REGEX = "^\\+?\\d{3,17}$";
     public final String value;
 
     /**

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_FIND_INVALID_PHONE;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,8 +32,7 @@ public class FindCommandParserTest {
     public void parse_missingKeywords_throwsParseException() {
         assertParseFailure(parser, " n/ ", Name.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, " p/ ",
-                "Phone keywords should only contain digits, may optionally start with a '+', "
-                        + "and must be between 1 and 17 digits long.");
+                MESSAGE_FIND_INVALID_PHONE);
         assertParseFailure(parser, " e/ ",
                 "Email keyword cannot be empty.");
         assertParseFailure(parser, " r/ ", Role.MESSAGE_CONSTRAINTS);
@@ -144,14 +144,11 @@ public class FindCommandParserTest {
     @Test
     public void parse_invalidPhone_throwsParseException() {
         assertParseFailure(parser, " p/-91234567",
-                "Phone keywords should only contain digits, may optionally start with a '+', "
-                        + "and must be between 1 and 17 digits long.");
+                MESSAGE_FIND_INVALID_PHONE);
         assertParseFailure(parser, " p/charlie",
-                "Phone keywords should only contain digits, may optionally start with a '+', "
-                        + "and must be between 1 and 17 digits long.");
+                MESSAGE_FIND_INVALID_PHONE);
         assertParseFailure(parser, " p/99999999999999999999",
-                "Phone keywords should only contain digits, may optionally start with a '+', "
-                        + "and must be between 1 and 17 digits long.");
+                MESSAGE_FIND_INVALID_PHONE);
     }
 
     @Test
@@ -252,7 +249,6 @@ public class FindCommandParserTest {
         assertParseFailure(parser, " n/Darren mm/3230 $$",
                 "Module keywords must contain only alphanumeric characters.");
         assertParseFailure(parser, " t/@dd mm/dd e/dd p/dd",
-                "Phone keywords should only contain digits, may optionally start with a '+', "
-                        + "and must be between 1 and 17 digits long.");
+                MESSAGE_FIND_INVALID_PHONE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -31,7 +31,8 @@ public class FindCommandParserTest {
     public void parse_missingKeywords_throwsParseException() {
         assertParseFailure(parser, " n/ ", Name.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, " p/ ",
-                "Phone number must only contain digits.");
+                "Phone keywords should only contain digits, may optionally start with a '+', "
+                        + "and must be between 1 and 17 digits long.");
         assertParseFailure(parser, " e/ ",
                 "Email keyword cannot be empty.");
         assertParseFailure(parser, " r/ ", Role.MESSAGE_CONSTRAINTS);
@@ -128,10 +129,10 @@ public class FindCommandParserTest {
 
         // Multiple phone numbers
         fieldKeywordMap.clear();
-        fieldKeywordMap.put(PersonContainsKeywordsPredicate.SearchField.PHONE, Arrays.asList("91234567", "98765432"));
+        fieldKeywordMap.put(PersonContainsKeywordsPredicate.SearchField.PHONE, Arrays.asList("91234567", "+98765432"));
         expectedFindCommand =
                 new FindCommand(new PersonContainsKeywordsPredicate(fieldKeywordMap));
-        assertParseSuccess(parser, " p/ 91234567 98765432", expectedFindCommand);
+        assertParseSuccess(parser, " p/91234567 +98765432", expectedFindCommand);
 
         // Multiple partial phone numbers
         fieldKeywordMap.clear();
@@ -142,10 +143,15 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_invalidPhone_throwsParseException() {
-        assertParseFailure(parser, " p/9123_4567",
-                "Phone number must only contain digits.");
+        assertParseFailure(parser, " p/-91234567",
+                "Phone keywords should only contain digits, may optionally start with a '+', "
+                        + "and must be between 1 and 17 digits long.");
         assertParseFailure(parser, " p/charlie",
-                "Phone number must only contain digits.");
+                "Phone keywords should only contain digits, may optionally start with a '+', "
+                        + "and must be between 1 and 17 digits long.");
+        assertParseFailure(parser, " p/99999999999999999999",
+                "Phone keywords should only contain digits, may optionally start with a '+', "
+                        + "and must be between 1 and 17 digits long.");
     }
 
     @Test
@@ -246,6 +252,7 @@ public class FindCommandParserTest {
         assertParseFailure(parser, " n/Darren mm/3230 $$",
                 "Module keywords must contain only alphanumeric characters.");
         assertParseFailure(parser, " t/@dd mm/dd e/dd p/dd",
-                "Phone number must only contain digits.");
+                "Phone keywords should only contain digits, may optionally start with a '+', "
+                        + "and must be between 1 and 17 digits long.");
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -20,14 +20,16 @@ import seedu.address.model.person.Phone;
 
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_PHONE_1 = "999999999999999999";
+    private static final String INVALID_PHONE_2 = "-123456";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_MODULE = "CS2103";
     private static final String REPEATED_INDEXES = "1 2 2";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_NAME_SPACES = "Rachel                Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE_1 = "123456";
+    private static final String VALID_PHONE_2 = "+98765432";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_MODULE_1 = "CS2103T";
     private static final String VALID_MODULE_2 = "CS2101";
@@ -91,19 +93,25 @@ public class ParserUtilTest {
 
     @Test
     public void parsePhone_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parsePhone(INVALID_PHONE));
+        assertThrows(ParseException.class, () -> ParserUtil.parsePhone(INVALID_PHONE_1));
+        assertThrows(ParseException.class, () -> ParserUtil.parsePhone(INVALID_PHONE_2));
     }
 
     @Test
     public void parsePhone_validValueWithoutWhitespace_returnsPhone() throws Exception {
-        Phone expectedPhone = new Phone(VALID_PHONE);
-        assertEquals(expectedPhone, ParserUtil.parsePhone(VALID_PHONE));
+        Phone expectedPhone = new Phone(VALID_PHONE_1);
+        assertEquals(expectedPhone, ParserUtil.parsePhone(VALID_PHONE_1));
+        expectedPhone = new Phone(VALID_PHONE_2);
+        assertEquals(expectedPhone, ParserUtil.parsePhone(VALID_PHONE_2));
     }
 
     @Test
     public void parsePhone_validValueWithWhitespace_returnsTrimmedPhone() throws Exception {
-        String phoneWithWhitespace = WHITESPACE + VALID_PHONE + WHITESPACE;
-        Phone expectedPhone = new Phone(VALID_PHONE);
+        String phoneWithWhitespace = WHITESPACE + VALID_PHONE_1 + WHITESPACE;
+        Phone expectedPhone = new Phone(VALID_PHONE_1);
+        assertEquals(expectedPhone, ParserUtil.parsePhone(phoneWithWhitespace));
+        phoneWithWhitespace = WHITESPACE + VALID_PHONE_2 + WHITESPACE;
+        expectedPhone = new Phone(VALID_PHONE_2);
         assertEquals(expectedPhone, ParserUtil.parsePhone(phoneWithWhitespace));
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -20,7 +20,7 @@ import seedu.address.model.person.Role;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_PHONE = "-651234";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_MODULE = "CS2103G";


### PR DESCRIPTION
- Added regex for phone numbers
- Allows `+` and between 3 to 17 digits.
- For find function, allows `+` and between 1 to 17 digits.
- `+` is optional for both.

Fixes #236 